### PR TITLE
Logic to add users to `docker` group

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - 'feature_*'
+      - 'feature/*'
       - 'master'
   schedule:
     - cron: '0 14 * * *'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        IMAGE: [ubuntu-18.04, ubuntu-16.04, debian-stretch]
+        IMAGE: [ubuntu-18.04, debian-stretch]
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ docker_user_home: "/home/{{ docker_user }}"
 docker_user_shell: /bin/bash
 docker_user_desired_state: present
 docker_repo_gpg_key: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
+docker_nonroot_users:
+  - www-data
+  - backup
+docker_add_nonroot_users_to_group_boolean: false
 docker_centos_pre_reqs:
   - device-mapper-persistent-data
   - lvm2
@@ -64,35 +68,37 @@ docker_repo_debian_desired_state: present
 
 ### Variables table:
 
-Variable                             | Description
------------------------------------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-docker_architecture_map              | Variable for system architecture types.
-docker_apps                          | Name of docker application packages require to be installed i.e. `docker-ce, docker-ce-cli, containerd.io`
-docker_apps_desired_state            | State of the docker_apps packages (i.e. `docker-ce, docker-ce-cli, containerd.io` packages). Whether to install, verify if available or to uninstall (i.e. ansible apt module values: `present`, `latest`, or `absent`)
-docker_service_name                  | Default service name for Docker.
-docker_service_desired_state         | Desired state for Docker service.
-docker_service_desired_boot_enabled  | Desired enabled/disabled state for Docker service.
-docker_service_desired_boot_enabled  | Desired enabled/disabled state for Docker service.
-docker_group                         | Name of the group that the docker owner will belong to. Any user that requires using docker app requires to be a member in the `docker` group.
-docker_group_desired_state           | `present` indicates creating the group if it doesn't exist. Alternative is `absent`.
-docker_user                          | Name of the user that the docker will be owned by.
-docker_user_home                     | Home directory for docker user.
-docker_user_shell                    | Shell for `docker_user`.
-docker_user_desired_state            | `present` indicates creating the user if it doesn't exist. Alternative is `absent`.
-docker_repo_gpg_key                  | GPG repo for docker repository
-docker_centos_pre_reqs               | Docker recommends the installation of both these packages on the EL/CentOS docker host system and as such, they are considered pre-requisites.
-docker_centos_pre_reqs_desired_state | Desired state for Docker pre-requisite apps on EL/CentOS systems.
-docker_repo_centos                   | Repository `baseurl` for Docker on EL/CentOS based systems.
-docker_repo_centos_name              | Repository name for Docker on EL/CentOS based systems.
-docker_repo_centos_description       | Description to be added in EL/CentOS based repository file for Docker.
-docker_repo_centos_gpgcheck          | Boolean for whether to perform gpg check against Docker on EL/CentOS based systems.
-docker_repo_centos_enabled           | Boolean to set so that Docker repository is enabled on EL/CentOS based systems.
-docker_repo_centos_filename          | Name of the repository file that will be stored at `/yum/sources.list.d/docker-ce.repo` on EL/CentOS based systems.
-docker_repo_centos_desired_state     | `present` indicates creating the repository file if it doesn't exist on EL/CentOS based systems. Alternative is `absent` (not recommended as it will prevent from installation of **docker** packages).
-docker_debian_pre_reqs_desired_state | Desired state for Docker pre-requisite apps on Debian family systems.
-docker_repo_debian                   | Docker repo URL for Debain systems. Utilized facts such as `ansible_architecture`.
-docker_repo_debain_filename          | Name of the repository file that will be stored at `/etc/apt/sources.list.d/` on Debian based systems.
-docker_repo_debian_desired_state     | `present` indicates creating the repository file if it doesn't exist on Debian based systems. Alternative is `absent` (not recommended as it will prevent from installation of **docker** packages).
+Variable                                  | Description
+----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+docker_architecture_map                   | Variable for system architecture types.
+docker_apps                               | Name of docker application packages require to be installed i.e. `docker-ce, docker-ce-cli, containerd.io`
+docker_apps_desired_state                 | State of the docker_apps packages (i.e. `docker-ce, docker-ce-cli, containerd.io` packages). Whether to install, verify if available or to uninstall (i.e. ansible apt module values: `present`, `latest`, or `absent`)
+docker_service_name                       | Default service name for Docker.
+docker_service_desired_state              | Desired state for Docker service.
+docker_service_desired_boot_enabled       | Desired enabled/disabled state for Docker service.
+docker_service_desired_boot_enabled       | Desired enabled/disabled state for Docker service.
+docker_group                              | Name of the group that the docker owner will belong to. Any user that requires using docker app requires to be a member in the `docker` group.
+docker_group_desired_state                | `present` indicates creating the group if it doesn't exist. Alternative is `absent`.
+docker_user                               | Name of the user that the docker will be owned by.
+docker_user_home                          | Home directory for docker user.
+docker_user_shell                         | Shell for `docker_user`.
+docker_user_desired_state                 | `present` indicates creating the user if it doesn't exist. Alternative is `absent`.
+docker_nonroot_users                      | List of users to add to the `docker` group
+docker_add_nonroot_users_to_group_boolean | Boolean variable. Values can either be `true` or `false`. Setting to `true` will run the task that will add additionally provided users in the variable `docker_nonroot_users` to the `docker` group. If set to `false`, the specific task that adds user to `docker` group will be skipped.
+docker_repo_gpg_key                       | GPG repo for docker repository
+docker_centos_pre_reqs                    | Docker recommends the installation of both these packages on the EL/CentOS docker host system and as such, they are considered pre-requisites.
+docker_centos_pre_reqs_desired_state      | Desired state for Docker pre-requisite apps on EL/CentOS systems.
+docker_repo_centos                        | Repository `baseurl` for Docker on EL/CentOS based systems.
+docker_repo_centos_name                   | Repository name for Docker on EL/CentOS based systems.
+docker_repo_centos_description            | Description to be added in EL/CentOS based repository file for Docker.
+docker_repo_centos_gpgcheck               | Boolean for whether to perform gpg check against Docker on EL/CentOS based systems.
+docker_repo_centos_enabled                | Boolean to set so that Docker repository is enabled on EL/CentOS based systems.
+docker_repo_centos_filename               | Name of the repository file that will be stored at `/yum/sources.list.d/docker-ce.repo` on EL/CentOS based systems.
+docker_repo_centos_desired_state          | `present` indicates creating the repository file if it doesn't exist on EL/CentOS based systems. Alternative is `absent` (not recommended as it will prevent from installation of **docker** packages).
+docker_debian_pre_reqs_desired_state      | Desired state for Docker pre-requisite apps on Debian family systems.
+docker_repo_debian                        | Docker repo URL for Debain systems. Utilized facts such as `ansible_architecture`.
+docker_repo_debain_filename               | Name of the repository file that will be stored at `/etc/apt/sources.list.d/` on Debian based systems.
+docker_repo_debian_desired_state          | `present` indicates creating the repository file if it doesn't exist on Debian based systems. Alternative is `absent` (not recommended as it will prevent from installation of **docker** packages).
 
 ## Dependencies
 
@@ -108,14 +114,25 @@ For default behaviour of role (i.e. installation of **docker** package) in ansib
     - darkwizard242.docker
 ```
 
-For customizing behavior of role (i.e. utilizing an existing or creating a new user to be added to docker group - example shown below is using `darkwizard242` as a user) in ansible playbooks.
+For customizing behavior of role (i.e. adding a list of users to be added to docker group - example shown below is adding `ubuntu` && `darkwizard` to `docker` group) in ansible playbooks.
 
 ```yaml
 - hosts: servers
   roles:
     - darkwizard242.docker
   vars:
-    docker_user: darkwizard242
+    docker_add_nonroot_users_to_group_boolean: true
+    docker_nonroot_users: darkwizard242
+```
+
+For customizing behavior of role (i.e. skipping the task that adds a list of users to be added to `docker` group) in ansible playbooks.
+
+```yaml
+- hosts: servers
+  roles:
+    - darkwizard242.docker
+  vars:
+    docker_add_nonroot_users_to_group_boolean: false
 ```
 
 For customizing behavior of role (i.e. un-installation of **docker-ce, docker-ce-cli, containerd.io** packages) in ansible playbooks.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker_repo_gpg_key: https://download.docker.com/linux/{{ ansible_distribution |
 docker_nonroot_users:
   - darkwizard242
   - ubuntu
-docker_add_nonroot_users_to_group_boolean: false
+docker_add_nonroot_users: false
 docker_centos_pre_reqs:
   - device-mapper-persistent-data
   - lvm2
@@ -68,37 +68,37 @@ docker_repo_debian_desired_state: present
 
 ### Variables table:
 
-Variable                                  | Description
------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-docker_architecture_map                   | Variable for system architecture types.
-docker_apps                               | Name of docker application packages require to be installed i.e. `docker-ce, docker-ce-cli, containerd.io`
-docker_apps_desired_state                 | State of the docker_apps packages (i.e. `docker-ce, docker-ce-cli, containerd.io` packages). Whether to install, verify if available or to uninstall (i.e. ansible apt module values: `present`, `latest`, or `absent`)
-docker_service_name                       | Default service name for Docker.
-docker_service_desired_state              | Desired state for Docker service.
-docker_service_desired_boot_enabled       | Desired enabled/disabled state for Docker service.
-docker_service_desired_boot_enabled       | Desired enabled/disabled state for Docker service.
-docker_group                              | Name of the group that the docker owner will belong to. Any user that requires using docker app requires to be a member in the `docker` group.
-docker_group_desired_state                | `present` indicates creating the group if it doesn't exist. Alternative is `absent`.
-docker_user                               | Name of the user that the docker will be owned by.
-docker_user_home                          | Home directory for docker user.
-docker_user_shell                         | Shell for `docker_user`.
-docker_user_desired_state                 | `present` indicates creating the user if it doesn't exist. Alternative is `absent`.
-docker_nonroot_users                      | List of users to add to the `docker` group
-docker_add_nonroot_users_to_group_boolean | Boolean variable. Values can either be `true` or `false`. Setting to `true` will run the task that will add additionally provided users in the variable `docker_nonroot_users` to the `docker` group. If set to `false`, the specific task that adds user to `docker` group will be skipped. Defaults to `false`
-docker_repo_gpg_key                       | GPG repo for docker repository
-docker_centos_pre_reqs                    | Docker recommends the installation of both these packages on the EL/CentOS docker host system and as such, they are considered pre-requisites.
-docker_centos_pre_reqs_desired_state      | Desired state for Docker pre-requisite apps on EL/CentOS systems.
-docker_repo_centos                        | Repository `baseurl` for Docker on EL/CentOS based systems.
-docker_repo_centos_name                   | Repository name for Docker on EL/CentOS based systems.
-docker_repo_centos_description            | Description to be added in EL/CentOS based repository file for Docker.
-docker_repo_centos_gpgcheck               | Boolean for whether to perform gpg check against Docker on EL/CentOS based systems.
-docker_repo_centos_enabled                | Boolean to set so that Docker repository is enabled on EL/CentOS based systems.
-docker_repo_centos_filename               | Name of the repository file that will be stored at `/yum/sources.list.d/docker-ce.repo` on EL/CentOS based systems.
-docker_repo_centos_desired_state          | `present` indicates creating the repository file if it doesn't exist on EL/CentOS based systems. Alternative is `absent` (not recommended as it will prevent from installation of **docker** packages).
-docker_debian_pre_reqs_desired_state      | Desired state for Docker pre-requisite apps on Debian family systems.
-docker_repo_debian                        | Docker repo URL for Debain systems. Utilized facts such as `ansible_architecture`.
-docker_repo_debain_filename               | Name of the repository file that will be stored at `/etc/apt/sources.list.d/` on Debian based systems.
-docker_repo_debian_desired_state          | `present` indicates creating the repository file if it doesn't exist on Debian based systems. Alternative is `absent` (not recommended as it will prevent from installation of **docker** packages).
+Variable                             | Description
+------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+docker_architecture_map              | Variable for system architecture types.
+docker_apps                          | Name of docker application packages require to be installed i.e. `docker-ce, docker-ce-cli, containerd.io`
+docker_apps_desired_state            | State of the docker_apps packages (i.e. `docker-ce, docker-ce-cli, containerd.io` packages). Whether to install, verify if available or to uninstall (i.e. ansible apt module values: `present`, `latest`, or `absent`)
+docker_service_name                  | Default service name for Docker.
+docker_service_desired_state         | Desired state for Docker service.
+docker_service_desired_boot_enabled  | Desired enabled/disabled state for Docker service.
+docker_service_desired_boot_enabled  | Desired enabled/disabled state for Docker service.
+docker_group                         | Name of the group that the docker owner will belong to. Any user that requires using docker app requires to be a member in the `docker` group.
+docker_group_desired_state           | `present` indicates creating the group if it doesn't exist. Alternative is `absent`.
+docker_user                          | Name of the user that the docker will be owned by.
+docker_user_home                     | Home directory for docker user.
+docker_user_shell                    | Shell for `docker_user`.
+docker_user_desired_state            | `present` indicates creating the user if it doesn't exist. Alternative is `absent`.
+docker_nonroot_users                 | List of users to add to the `docker` group
+docker_add_nonroot_users             | Boolean variable. Values can either be `true` or `false`. Setting to `true` will run the task that will add additionally provided users in the variable `docker_nonroot_users` to the `docker` group. If set to `false`, the specific task that adds user to `docker` group will be skipped. Defaults to `false`
+docker_repo_gpg_key                  | GPG repo for docker repository
+docker_centos_pre_reqs               | Docker recommends the installation of both these packages on the EL/CentOS docker host system and as such, they are considered pre-requisites.
+docker_centos_pre_reqs_desired_state | Desired state for Docker pre-requisite apps on EL/CentOS systems.
+docker_repo_centos                   | Repository `baseurl` for Docker on EL/CentOS based systems.
+docker_repo_centos_name              | Repository name for Docker on EL/CentOS based systems.
+docker_repo_centos_description       | Description to be added in EL/CentOS based repository file for Docker.
+docker_repo_centos_gpgcheck          | Boolean for whether to perform gpg check against Docker on EL/CentOS based systems.
+docker_repo_centos_enabled           | Boolean to set so that Docker repository is enabled on EL/CentOS based systems.
+docker_repo_centos_filename          | Name of the repository file that will be stored at `/yum/sources.list.d/docker-ce.repo` on EL/CentOS based systems.
+docker_repo_centos_desired_state     | `present` indicates creating the repository file if it doesn't exist on EL/CentOS based systems. Alternative is `absent` (not recommended as it will prevent from installation of **docker** packages).
+docker_debian_pre_reqs_desired_state | Desired state for Docker pre-requisite apps on Debian family systems.
+docker_repo_debian                   | Docker repo URL for Debain systems. Utilized facts such as `ansible_architecture`.
+docker_repo_debain_filename          | Name of the repository file that will be stored at `/etc/apt/sources.list.d/` on Debian based systems.
+docker_repo_debian_desired_state     | `present` indicates creating the repository file if it doesn't exist on Debian based systems. Alternative is `absent` (not recommended as it will prevent from installation of **docker** packages).
 
 ## Dependencies
 
@@ -121,7 +121,7 @@ For customizing behavior of role (i.e. adding a list of users to be added to doc
   roles:
     - darkwizard242.docker
   vars:
-    docker_add_nonroot_users_to_group_boolean: true
+    docker_add_nonroot_users: true
     docker_nonroot_users:
       - darkwizard242
       - ubuntu
@@ -134,7 +134,7 @@ For customizing behavior of role (i.e. skipping the task that adds a list of use
   roles:
     - darkwizard242.docker
   vars:
-    docker_add_nonroot_users_to_group_boolean: false
+    docker_add_nonroot_users: false
 ```
 
 For customizing behavior of role (i.e. un-installation of **docker-ce, docker-ce-cli, containerd.io** packages) in ansible playbooks.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ docker_user_shell: /bin/bash
 docker_user_desired_state: present
 docker_repo_gpg_key: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
 docker_nonroot_users:
-  - www-data
-  - backup
+  - darkwizard242
+  - ubuntu
 docker_add_nonroot_users_to_group_boolean: false
 docker_centos_pre_reqs:
   - device-mapper-persistent-data
@@ -69,7 +69,7 @@ docker_repo_debian_desired_state: present
 ### Variables table:
 
 Variable                                  | Description
------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 docker_architecture_map                   | Variable for system architecture types.
 docker_apps                               | Name of docker application packages require to be installed i.e. `docker-ce, docker-ce-cli, containerd.io`
 docker_apps_desired_state                 | State of the docker_apps packages (i.e. `docker-ce, docker-ce-cli, containerd.io` packages). Whether to install, verify if available or to uninstall (i.e. ansible apt module values: `present`, `latest`, or `absent`)
@@ -84,7 +84,7 @@ docker_user_home                          | Home directory for docker user.
 docker_user_shell                         | Shell for `docker_user`.
 docker_user_desired_state                 | `present` indicates creating the user if it doesn't exist. Alternative is `absent`.
 docker_nonroot_users                      | List of users to add to the `docker` group
-docker_add_nonroot_users_to_group_boolean | Boolean variable. Values can either be `true` or `false`. Setting to `true` will run the task that will add additionally provided users in the variable `docker_nonroot_users` to the `docker` group. If set to `false`, the specific task that adds user to `docker` group will be skipped.
+docker_add_nonroot_users_to_group_boolean | Boolean variable. Values can either be `true` or `false`. Setting to `true` will run the task that will add additionally provided users in the variable `docker_nonroot_users` to the `docker` group. If set to `false`, the specific task that adds user to `docker` group will be skipped. Defaults to `false`
 docker_repo_gpg_key                       | GPG repo for docker repository
 docker_centos_pre_reqs                    | Docker recommends the installation of both these packages on the EL/CentOS docker host system and as such, they are considered pre-requisites.
 docker_centos_pre_reqs_desired_state      | Desired state for Docker pre-requisite apps on EL/CentOS systems.
@@ -122,7 +122,9 @@ For customizing behavior of role (i.e. adding a list of users to be added to doc
     - darkwizard242.docker
   vars:
     docker_add_nonroot_users_to_group_boolean: true
-    docker_nonroot_users: darkwizard242
+    docker_nonroot_users:
+      - darkwizard242
+      - ubuntu
 ```
 
 For customizing behavior of role (i.e. skipping the task that adds a list of users to be added to `docker` group) in ansible playbooks.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,10 @@ docker_user: docker
 docker_user_home: "/home/{{ docker_user }}"
 docker_user_shell: /bin/bash
 docker_user_desired_state: present
+docker_nonroot_users:
+  - www-data
+  - backup
+docker_add_nonroot_users_to_group_boolean: true
 docker_repo_gpg_key: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
 
 # CentOS Stuff

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ docker_user_desired_state: present
 docker_nonroot_users:
   - www-data
   - backup
-docker_add_nonroot_users_to_group_boolean: false
+docker_add_nonroot_users: false
 docker_repo_gpg_key: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
 
 # CentOS Stuff

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ docker_user_desired_state: present
 docker_nonroot_users:
   - www-data
   - backup
-docker_add_nonroot_users_to_group_boolean: true
+docker_add_nonroot_users_to_group_boolean: false
 docker_repo_gpg_key: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
 
 # CentOS Stuff

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,7 +4,7 @@
   roles:
     - role: darkwizard242.docker
   vars:
-    docker_add_nonroot_users_to_group_boolean: true
+    docker_add_nonroot_users_to_group_boolean: false
     docker_nonroot_users:
       - www-data
       - backup

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,3 +3,8 @@
   hosts: all
   roles:
     - role: darkwizard242.docker
+  vars:
+    docker_add_nonroot_users_to_group_boolean: true
+    docker_nonroot_users:
+      - www-data
+      - backup

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,7 +4,7 @@
   roles:
     - role: darkwizard242.docker
   vars:
-    docker_add_nonroot_users_to_group_boolean: true
+    docker_add_nonroot_users: true
     docker_nonroot_users:
       - www-data
       - backup

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,7 +4,7 @@
   roles:
     - role: darkwizard242.docker
   vars:
-    docker_add_nonroot_users_to_group_boolean: false
+    docker_add_nonroot_users_to_group_boolean: true
     docker_nonroot_users:
       - www-data
       - backup

--- a/tasks/user_group.yml
+++ b/tasks/user_group.yml
@@ -17,11 +17,11 @@
     shell: "{{ docker_user_shell }}"
     state: "{{ docker_user_desired_state }}"
 
-- name: Add users "{{ docker_user }}" to group "{{ docker_group }}" if specified.
+- name: Add users "{{ docker_nonroot_users }}" to group "{{ docker_group }}" if specified.
   become: true
   user:
     name: "{{ item }}"
-    group: "{{ docker_group }}"
+    groups: "{{ docker_group }}"
     append: yes
   with_items: "{{ docker_nonroot_users }}"
   # when:

--- a/tasks/user_group.yml
+++ b/tasks/user_group.yml
@@ -24,5 +24,4 @@
     groups: "{{ docker_group }}"
     append: yes
   with_items: "{{ docker_nonroot_users }}"
-  when:
-    - docker_add_nonroot_users_to_group_boolean
+  when: docker_add_nonroot_users

--- a/tasks/user_group.yml
+++ b/tasks/user_group.yml
@@ -24,5 +24,5 @@
     groups: "{{ docker_group }}"
     append: yes
   with_items: "{{ docker_nonroot_users }}"
-  # when:
-  #   - docker_add_nonroot_users_to_group_boolean
+  when:
+    - docker_add_nonroot_users_to_group_boolean

--- a/tasks/user_group.yml
+++ b/tasks/user_group.yml
@@ -16,3 +16,13 @@
     home: "{{ docker_user_home }}"
     shell: "{{ docker_user_shell }}"
     state: "{{ docker_user_desired_state }}"
+
+- name: Add users "{{ docker_user }}" to group "{{ docker_group }}" if specified.
+  become: true
+  user:
+    name: "{{ item }}"
+    group: "{{ docker_group }}"
+    append: yes
+  with_items: "{{ docker_nonroot_users }}"
+  # when:
+  #   - docker_add_nonroot_users_to_group_boolean


### PR DESCRIPTION
## Summary
This PR relates to the enhancement for ISSUE #7 as reported by @blmhemu 
* Remove CI support for Ubuntu 16.04 as EOL.
* Update build workflow for `feature/*` branches.
* Task that will add users to `docker` group.
* Logic to handle when a user doesn't wish to add any non-root user to docker group.
* Variable definitions:
  *  `docker_add_nonroot_users_to_group_boolean` | Boolean variable. Values can either be `true` or `false`. Setting to `true` will run the task that will add additionally provided users in the variable `docker_nonroot_users` to the `docker` group. If set to `false`, the specific task that adds user to `docker` group will be skipped.
  *  `docker_nonroot_users` | List of users to add to the `docker` group
  * README updates
  * molecule to test while setting `docker_add_nonroot_users_to_group_boolean` to true and passing www-data, backup as dummy users to `docker_nonroot_users`

## Examples:
For customizing behavior of role (i.e. adding a list of users to be added to docker group - example shown below is adding `ubuntu` && `darkwizard` to `docker` group) in ansible playbooks.

```yaml
- hosts: servers
  roles:
    - darkwizard242.docker
  vars:
    docker_add_nonroot_users_to_group_boolean: true
    docker_nonroot_users: 
      - darkwizard242
      - ubuntu
```

For customizing behavior of role (i.e. skipping the task that adds a list of users to be added to `docker` group) in ansible playbooks.

```yaml
- hosts: servers
  roles:
    - darkwizard242.docker
  vars:
    docker_add_nonroot_users_to_group_boolean: false
```